### PR TITLE
[WIP] Convert to/from Elixir calendar types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /tmp
 erl_crash.dump
 *.ez
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: elixir
 elixir:
-  - 1.2.1
+  - 1.3.0
 otp_release:
-  - 18.2.1
+  - 18.3
 after_script:
   - MIX_ENV=docs mix deps.get
   - MIX_ENV=docs mix inch.report

--- a/lib/good_times.ex
+++ b/lib/good_times.ex
@@ -1,5 +1,5 @@
 defmodule GoodTimes do
-  @vsn "1.1.1"
+  @vsn "1.2.0"
   @doc false
   def version, do: @vsn
 

--- a/lib/good_times/convert.ex
+++ b/lib/good_times/convert.ex
@@ -84,13 +84,13 @@ defmodule GoodTimes.Convert do
   ## Examples
 
       iex> {{2015, 2, 27}, {18, 30, 45}} |> to_elixir_datetime
-      %DateTime{year: 2015, month: 2, day: 27, hour: 18, minute: 30, second: 45, micro_second: 0, calendar: Calendar.ISO, std_offset: nil, time_zone: nil, utc_offset: nil, zone_abbr: nil}
+      %DateTime{year: 2015, month: 2, day: 27, hour: 18, minute: 30, second: 45, microsecond: 0, calendar: Calendar.ISO, std_offset: nil, time_zone: nil, utc_offset: nil, zone_abbr: nil}
   """
   @spec to_elixir_datetime(GoodTimes.datetime) :: DateTime.t
   def to_elixir_datetime({{year, month, day}, {hour, minute, second}}) do
     %DateTime{
       calendar: Calendar.ISO, year: year, month: month, day: day,
-      hour: hour, minute: minute, second: second, micro_second: 0,
+      hour: hour, minute: minute, second: second, microsecond: 0,
       std_offset: nil, time_zone: nil, utc_offset: nil, zone_abbr: nil
     }
   end

--- a/lib/good_times/convert.ex
+++ b/lib/good_times/convert.ex
@@ -19,8 +19,15 @@ defmodule GoodTimes.Convert do
 
       iex> {2015, 2, 27} |> from_date
       {{2015, 2, 27}, {0, 0, 0}}
+
+      iex> %Date{year: 2016, month: 4, day: 1} |> from_date
+      {{2016, 4, 1}, {0, 0, 0}}
   """
+  @spec from_date(Calendar.Date.t) :: GoodTimes.datetime
   @spec from_date(GoodTimes.date) :: GoodTimes.datetime
+  def from_date(%Date{year: year, month: month, day: day, calendar: Calendar.ISO}) do
+    {{year, month, day}, {0, 0, 0}}
+  end
   def from_date(date), do: {date, {0, 0, 0}}
 
   @doc """
@@ -44,4 +51,47 @@ defmodule GoodTimes.Convert do
   """
   @spec to_time(GoodTimes.datetime) :: GoodTimes.time
   def to_time({_, time}), do: time
+
+  @doc """
+  Returns the date portion of a datetime as a Calendar.Date.
+
+  ## Examples
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> to_elixir_date
+      %Date{year: 2015, month: 2, day: 27, calendar: Calendar.ISO}
+  """
+  @spec to_elixir_date(GoodTimes.datetime) :: Date.t
+  def to_elixir_date({{year, month, day}, _}) do
+    %Date{year: year, month: month, day: day}
+  end
+
+  @doc """
+  Returns the time portion of a datetime as a Calendar.Time.
+
+  ## Examples
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> to_elixir_time
+      %Time{hour: 18, minute: 30, second: 45}
+  """
+  @spec to_elixir_time(GoodTimes.datetime) :: Time.t
+  def to_elixir_time({_, {hour, minute, second}}) do
+    %Time{hour: hour, minute: minute, second: second}
+  end
+
+  @doc """
+  Returns the datetime as a Calendar.DateTime.
+
+  ## Examples
+
+      iex> {{2015, 2, 27}, {18, 30, 45}} |> to_elixir_datetime
+      %DateTime{year: 2015, month: 2, day: 27, hour: 18, minute: 30, second: 45, micro_second: 0, calendar: Calendar.ISO, std_offset: nil, time_zone: nil, utc_offset: nil, zone_abbr: nil}
+  """
+  @spec to_elixir_datetime(GoodTimes.datetime) :: DateTime.t
+  def to_elixir_datetime({{year, month, day}, {hour, minute, second}}) do
+    %DateTime{
+      calendar: Calendar.ISO, year: year, month: month, day: day,
+      hour: hour, minute: minute, second: second, micro_second: 0,
+      std_offset: nil, time_zone: nil, utc_offset: nil, zone_abbr: nil
+    }
+  end
 end

--- a/lib/good_times/convert.ex
+++ b/lib/good_times/convert.ex
@@ -71,11 +71,11 @@ defmodule GoodTimes.Convert do
   ## Examples
 
       iex> {{2015, 2, 27}, {18, 30, 45}} |> to_elixir_time
-      %Time{hour: 18, minute: 30, second: 45}
+      %Time{hour: 18, minute: 30, second: 45, microsecond: 0}
   """
   @spec to_elixir_time(GoodTimes.datetime) :: Time.t
   def to_elixir_time({_, {hour, minute, second}}) do
-    %Time{hour: hour, minute: minute, second: second}
+    %Time{hour: hour, minute: minute, second: second, microsecond: 0}
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule GoodTimes.Mixfile do
       {:earmark, "~> 0.2", only: :dev},
       {:ex_doc, "~> 0.11", only: :dev},
       {:mix_test_watch, "~> 0.2", only: :dev},
-      {:inch_ex, ">= 0.4.0", only: :docs}
+      {:inch_ex, ">= 0.5.0", only: :docs}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,10 +4,10 @@ defmodule GoodTimes.Mixfile do
   def project do
     [
       app: :good_times,
-      version: "1.1.1",
+      version: "1.2.0",
       name: "GoodTimes",
       source_url: "https://github.com/DevL/good_times",
-      elixir: "~> 1.0",
+      elixir: "~> 1.3",
       deps: deps,
       description: description,
       package: package
@@ -37,6 +37,7 @@ defmodule GoodTimes.Mixfile do
     [
       {:earmark, "~> 0.2", only: :dev},
       {:ex_doc, "~> 0.11", only: :dev},
+      {:mix_test_watch, "~> 0.2", only: :dev},
       {:inch_ex, ">= 0.4.0", only: :docs}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule GoodTimes.Mixfile do
       version: "1.2.0",
       name: "GoodTimes",
       source_url: "https://github.com/DevL/good_times",
-      elixir: "~> 1.3",
+      elixir: "~> 1.3.0-dev",
       deps: deps,
       description: description,
       package: package

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
 %{"earmark": {:hex, :earmark, "0.2.1"},
   "ex_doc": {:hex, :ex_doc, "0.11.3"},
+  "fs": {:hex, :fs, "0.9.2"},
   "inch_ex": {:hex, :inch_ex, "0.4.0"},
+  "mix_test_watch": {:hex, :mix_test_watch, "0.2.6"},
   "poison": {:hex, :poison, "1.5.2"}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,8 @@
-%{"earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.3"},
-  "fs": {:hex, :fs, "0.9.2"},
-  "inch_ex": {:hex, :inch_ex, "0.4.0"},
-  "mix_test_watch": {:hex, :mix_test_watch, "0.2.6"},
-  "poison": {:hex, :poison, "1.5.2"}}
+%{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
+  "credo": {:hex, :credo, "0.4.1", "e67c65b89662675e7278b45c9dc4633e18797cf4481ebc5b47340ccbcfe721c9", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.3", "bb16cb3f4135d880ce25279dc19a9d70802bc4f4942f0c3de9e4862517ae3ace", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
+  "inch_ex": {:hex, :inch_ex, "0.5.2", "610f13796e188f9715c32f7c3f52d789bfc612d993e3a62462a755b12b24fc67", [:mix], [{:credo, "~> 0.4", [hex: :credo, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
+  "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
+  "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []}}


### PR DESCRIPTION
This is just a concretisation of some ideas mentioned in #2. I'm not overly fond of the function names (e.g. `to_elixir_date`, `to_elixir_datetime`).

Obviously, the Travis builds will be broken until Elixir 1.3 has been released.
